### PR TITLE
Hybrid technique: Selecting a concrete rendering variant during the LOD stage

### DIFF
--- a/shader_includes/host_device_shared.h
+++ b/shader_includes/host_device_shared.h
@@ -64,7 +64,7 @@
 #define TILE_PATCHES_BUFFER_ELEMENTS           MAX_PATCHES_PER_TILE * 20736
 
 // Draws points and lines, visualizing how pass2x evaluates the split decisions
-#define DRAW_PATCH_EVAL_DEBUG_VIS 0
+#define DRAW_PATCH_EVAL_DEBUG_VIS 1
 
 // Data size of the big brain dataset to be loaded (note that only even numbers will be properly shaded (sorry!), i.e., e.g.: 10x10, 100x100, or the maximum of 140x140)
 #define SH_BRAIN_DATA_SIZE_X      140

--- a/shader_includes/parametric_functions/sh_glyph.glsl
+++ b/shader_includes/parametric_functions/sh_glyph.glsl
@@ -2459,9 +2459,8 @@ vec3 get_sh_glyph(float u, float v, uvec3 userData)
 
 	float f = 0.0;
     if (isBigDataset) {
-        dataset_sh_coeffs coeffs = uBigDataset.mEntries[glyphId];
         for (int i = 0; i < 91; i++) {
-            f += out_shs[i] * coeffs.mCoeffs[i];
+            f += out_shs[i] * uBigDataset.mEntries[glyphId].mCoeffs[i];
         }
     }
     else {

--- a/shader_includes/util/glsl_helpers.glsl
+++ b/shader_includes/util/glsl_helpers.glsl
@@ -179,3 +179,29 @@ int guesstimateNumberOfPixelsCovered(vec3 corner1, vec3 corner2, vec3 corner3, v
     return int(ceil(pixelDists.x) * ceil(pixelDists.y));
 }
 
+// Example usage: 
+// var subgroupInvocationId = calcInvocationIdFrom2DIndices(gl_LocalInvocationID, gl_WorkGroupSize);
+uint calcInvocationIdFrom2DIndices(uvec2 indices, uvec2 size)
+{
+	return indices.y * size.x + indices.x;
+}
+
+// Get a point that is bilinearly interpolated according to u and v interpolation factor
+vec3 getBilinearInterpolated(vec3 Pos0, vec3 PosU, vec3 PosV, vec3 PosUV, float u, float v)
+{
+	vec3 P =  Pos0  * (1.0 - u) * (1.0 - v)
+			+ PosU  * u * (1.0 - v) 
+			+ PosV  * (1.0 - u) * v
+			+ PosUV * u * v;
+	return P;
+}
+
+// Get a point that is bilinearly interpolated according to u and v interpolation factor
+vec4 getBilinearInterpolated(vec4 Pos0, vec4 PosU, vec4 PosV, vec4 PosUV, float u, float v)
+{
+	vec4 P =  Pos0  * (1.0 - u) * (1.0 - v)
+			+ PosU  * u * (1.0 - v) 
+			+ PosV  * (1.0 - u) * v
+			+ PosUV * u * v;
+	return P;
+}

--- a/shaders/pass2x_patch_lod.comp
+++ b/shaders/pass2x_patch_lod.comp
@@ -251,6 +251,9 @@ bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec
 	vec3 nrmU   = subgroupShuffle(nrm0  , neighborX );
 	vec3 nrmV   = subgroupShuffle(nrm0  , neighborY );
 	vec3 nrmUV  = subgroupShuffle(nrm0  , neighborXY);
+#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
+	writeToCombinedAttachment(ivec2(toScreen(toCS(pos0WS)).xy), 0.0001, nrm0);
+#endif
 
 	uint different = 0;
 	uint total = 0;
@@ -268,20 +271,26 @@ bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec
 		vec2(0.2,      0.2     )
 	};
 	
-	for (uint i = 0; i < NumTests; ++i) {
-		// Calc interpolated normal:
-		vec2 curOff    = offsets[i];
-		vec3 lerpedNrm = getBilinearInterpolated(nrm0, nrmU, nrmV, nrmUV, curOff.x, curOff.y);
+	if (gl_LocalInvocationID.x < gl_WorkGroupSize.x - 1 && gl_LocalInvocationID.y < gl_WorkGroupSize.y - 1) {
+		for (uint i = 0; i < NumTests; ++i) {
+			// Calc interpolated normal:
+			vec2 curOff     = offsets[i];
+			vec3 lerpedNrm  = getBilinearInterpolated(nrm0, nrmU, nrmV, nrmUV, curOff.x, curOff.y);
 
-		// Calc subsampled normal:
-		vec4 sspos0WS = tM * paramToWS(uParam + onePxParamRange.x * curOff.x, vParam + onePxParamRange.y * curOff.y, curveIndex, userData);
-		vec4 ssposU   = subgroupShuffle(sspos0WS, neighborX);
-		vec4 ssposV   = subgroupShuffle(sspos0WS, neighborY);
-		if (gl_LocalInvocationID.x < gl_WorkGroupSize.x - 1 && gl_LocalInvocationID.y < gl_WorkGroupSize.y - 1) {
-			vec3 ssnrm0   = normalize(cross(ssposU.xyz - sspos0WS.xyz, ssposV.xyz - sspos0WS.xyz));
+			// Calc subsampled normal:
+			vec4 ssposU     = tM * paramToWS(uParam + onePxParamRange.x * curOff.x, vParam                               , curveIndex, userData);
+			vec4 ssposV     = tM * paramToWS(uParam                               , vParam + onePxParamRange.y * curOff.y, curveIndex, userData);
+			vec3 ssnrm      = normalize(cross(ssposU.xyz - pos0WS.xyz, ssposV.xyz - pos0WS.xyz));
+
+//#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
+//			if (i == 0) {
+//				writeToCombinedAttachment(ivec2(toScreen(toCS(pos0WS)).xy) + ivec2(-5, 10), 0.0001, lerpedNrm);
+//				writeToCombinedAttachment(ivec2(toScreen(toCS(pos0WS)).xy) + ivec2( 5, 10), 0.0001, ssnrm);
+//			}
+//#endif
 
 			// Compare interpolated with subsampled normal:
-			float angleDiff            = dot(normalize(lerpedNrm), ssnrm0);
+			float angleDiff = dot(normalize(lerpedNrm), ssnrm);
 			const float angleThreshold = 0.98; // 0.97 => ~14° | 0.98 => ~11° | 0.99 => ~8°
 			different += angleDiff < angleThreshold ? 1 : 0;
 			total += NumTests;

--- a/shaders/pass2x_patch_lod.comp
+++ b/shaders/pass2x_patch_lod.comp
@@ -64,7 +64,10 @@ layout(set = 4, binding = 0) buffer BigDataset { dataset_sh_coeffs mEntries[]; }
 #include "../shader_includes/parametric_functions/shape_functions.glsl"
 #include "../shader_includes/parametric_curve_helpers.glsl"
 
+
 #if DRAW_PATCH_EVAL_DEBUG_VIS
+#define DRAW_PATCH_EVAL_DEBUG_VIS_SCREEN_DISTANCES 0
+#define DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL   0
 layout(set = 5, binding = 0, r64ui) uniform restrict volatile u64image2D uCombinedAttachment;
 #if STATS_ENABLED
 layout(set = 5, binding = 1, r32ui) uniform restrict uimage2D uHeatmapImage;
@@ -75,9 +78,11 @@ layout(set = 5, binding = 1, r32ui) uniform restrict uimage2D uHeatmapImage;
 #define DEBUG_COLOR_X         vec4(1.0, 1.0 , 0.0 , 1.0)
 #define DEBUG_COLOR_Y         vec4(1.0, 0.3 , 0.0 , 1.0)
 #define DEBUG_COLOR_XTRA      vec4(1.0, 0.05, 0.05, 1.0)
+#define DEBUG_COLOR_SUBSAMPLE vec4(0.1, 0.6 , 1.0 , 1.0)
 #define DEBUG_VIS_WRAP_BEGIN  if (0 == pushConstants.mPatchLodLevel) {
 #define DEBUG_VIS_WRAP_END    }
 
+#if DRAW_PATCH_EVAL_DEBUG_VIS_SCREEN_DISTANCES
 // DDA Function for line generation 
 void DDA(ivec2 pt0, ivec2 pt1, vec4 color) 
 { 
@@ -101,6 +106,7 @@ void DDA(ivec2 pt0, ivec2 pt1, vec4 color)
         Y += Yinc; // increment in y at each step 
     } 
 } 
+#endif
 #endif
 
 // +------------------------------------------------------------------------------+
@@ -177,7 +183,7 @@ void evalSplitDecision(bool aTransposeEval, vec2 aParamsStart, vec2 aParamsRange
 	const vec2 neighborScreenCoords = subgroupShuffle(screenCoords, neighborIndex);
 	const float neighborDist = length(screenCoords - neighborScreenCoords); // TODO: Optimize performance with squared distance
 
-#if DRAW_PATCH_EVAL_DEBUG_VIS
+#if DRAW_PATCH_EVAL_DEBUG_VIS_SCREEN_DISTANCES
 	{ DEBUG_VIS_WRAP_BEGIN
 		vec4 dbgColor = aTransposeEval ? DEBUG_COLOR_Y : DEBUG_COLOR_X;
 		for (int i = -DEBUG_POINT_HALF_SIZE; i <= DEBUG_POINT_HALF_SIZE; ++i) {
@@ -214,9 +220,92 @@ void evalSplitDecision(bool aTransposeEval, vec2 aParamsStart, vec2 aParamsRange
 	}
 }
 
-// renderingVariantIndex:  [0] = Tess_noAA, [1] = Tess_8xSS, [2] = Tess_4xSS_8xMS, [3] = PointRendered_direct, [4] = PointRendered_4xSS_local_fb, [5] = Hybrid
-void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn) 
+bool measureSubpixelBumpiness(float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, mat4 aTM, int curveIndex, uvec3 userData)
 {
+	// Parameter ranges for ~1px:
+	vec2 parameterRange      = vec2(uEnd - uStart, vEnd - vStart);
+	vec2 onePxParamRange     = parameterRange / screenDists;
+	vec2 quarterPxParamRange = onePxParamRange;
+	vec2 middlePxStartParams = vec2(
+		uStart + parameterRange.x * 0.5 - onePxParamRange.x ,
+		vStart + parameterRange.y * 0.5 - onePxParamRange.y
+	);
+	
+	// Start in the middle:
+	float vParamPing = middlePxStartParams.y;
+	float vParamPong = vParamPing + quarterPxParamRange.y;
+	float uParam     = middlePxStartParams.x + gl_SubgroupInvocationID * quarterPxParamRange.x;
+	vec4  posPingWS  = aTM * paramToWS(uParam, vParamPing, curveIndex, userData);
+	vec4  posPongWS  = aTM * paramToWS(uParam, vParamPong, curveIndex, userData);
+	const uint neighborIndex = gl_SubgroupInvocationID == 31 ? gl_SubgroupInvocationID : gl_SubgroupInvocationID - 1;
+	vec4  posPongWSN = subgroupShuffle(posPongWS, neighborIndex);
+	vec3  normalPong = cross(normalize(posPongWSN.xyz - posPongWS.xyz), normalize(posPongWS.xyz - posPingWS.xyz));
+	vec3  normalPing = normalPong;
+	int sameDirCount = 0;
+	
+	for (int i = 0; i < 8; ++i) {
+		// Next row:
+		vParamPing   = vParamPong;
+		vParamPong  += quarterPxParamRange.y;
+		posPingWS    = posPongWS;
+		posPongWS    = aTM * paramToWS(uParam, vParamPong, curveIndex, userData);
+		posPongWSN   = subgroupShuffle(posPongWS, neighborIndex);
+
+		normalPing   = normalPong;
+		normalPong   = cross(normalize(posPongWSN.xyz - posPongWS.xyz), normalize(posPongWS.xyz - posPingWS.xyz));
+		vec3 normalPongN = subgroupShuffle(normalPong, neighborIndex);
+
+		vec3 rotU    = cross(normalPong, normalPongN);
+		vec3 rotUN   = subgroupShuffle(rotU, neighborIndex);
+		vec3 rotV    = cross(normalPing, normalPong);
+		vec3 rotVN   = subgroupShuffle(rotV, neighborIndex);
+
+		int sameDir      = gl_SubgroupInvocationID > 8 ? 0
+						 : ( (dot(rotU, rotUN) > 0.0 ? 1 : 0) 
+						   + (dot(rotV, rotVN) > 0.0 ? 1 : 0));
+		sameDirCount    += subgroupAdd(sameDir);
+
+#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
+		if (gl_SubgroupInvocationID <= 8) {
+			writeToCombinedAttachment(ivec2(toScreen(toCS(posPongWS)).xy), 0.0001, normalPong);
+		}
+#endif
+	}
+
+	return sameDirCount < 64;
+}
+
+// renderingVariantIndex:  [0] = Tess_noAA, [1] = Tess_8xSS, [2] = Tess_4xSS_8xMS, [3] = PointRendered_direct, [4] = PointRendered_4xSS_local_fb, [5] = Hybrid
+void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn, mat4 aTM, int curveIndex, uvec3 userData) 
+{
+	// Before we decide about them splits, see if we must decide upon them different rendering variants (HYBRID METHOD):
+	if (HYBRID_VARIANT_INDEX == renderingVariantIndex) { 
+		if (gl_WorkGroupID.x % 2 == 0) {
+			renderingVariantIndex = 0;
+		}
+		else {
+			renderingVariantIndex = 4;
+		}
+		// TODO:  ^ Implement a proper heuristic => see here v
+
+		bool isBumpy = measureSubpixelBumpiness(uStart, uEnd, vStart, vEnd, screenDists, aTM, curveIndex, userData);
+		renderingVariantIndex = isBumpy ? 4 : 0;
+	}
+
+	if (!subgroupElect() || gl_LocalInvocationID.z != 0) { // Only one thread is allowed to do that. // Only z==0 writes the split data
+		return;
+	}
+		// Before we decide about them splits, see if we must decide upon them different rendering variants (HYBRID METHOD):
+	if (HYBRID_VARIANT_INDEX == renderingVariantIndex) { 
+		// TODO: Implement a proper heuristic
+		if (gl_WorkGroupID.x % 2 == 0) {
+			renderingVariantIndex = 0;
+		}
+		else {
+			renderingVariantIndex = 4;
+		}
+	}
+
 //	if (uStart < 0.8 || vStart < 1.8) return;
 	const uint insertIdx 
 		= MAX_INDIRECT_DISPATCHES * renderingVariantIndex // <-- start offset (depending on rendering variant)
@@ -242,22 +331,25 @@ void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart
 }
 
 // renderingVariantIndex:  [0] = Tess_noAA, [1] = Tess_8xSS, [2] = Tess_4xSS_8xMS, [3] = PointRendered_direct, [4] = PointRendered_4xSS_local_fb, [5] = Hybrid
-void patchOut(int renderingVariantIndex, const uint levelIn, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn) 
+void patchOut(int renderingVariantIndex, const uint levelIn, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn, mat4 aTM, int curveIndex, uvec3 userData) 
 {
 	// out (from ping->pong):
 	uint maxLevel = MAX_PATCH_SUBDIV_STEPS-1;
 
 	if (levelIn != maxLevel) { // Split and continue with ping->pong
-		const uint levelOut = levelIn + 1;
-		const uint insertIdx = atomicAdd(uPatchLodCount.mDispatchCounts[levelOut].x, 1);
-		uPatchLodPong.mElements[insertIdx].mParams           = vec4(uStart, uEnd, vStart, vEnd);
-		uPatchLodPong.mElements[insertIdx].mObjectIdUserData = uPatchLodPing.mElements[elementIdxIn].mObjectIdUserData;
+		if (subgroupElect() && gl_LocalInvocationID.z == 0) { // Only one thread is allowed to do that. // Only z==0 writes the split data
+			const uint levelOut = levelIn + 1;
+			const uint insertIdx = atomicAdd(uPatchLodCount.mDispatchCounts[levelOut].x, 1);
+			uPatchLodPong.mElements[insertIdx].mParams           = vec4(uStart, uEnd, vStart, vEnd);
+			uPatchLodPong.mElements[insertIdx].mObjectIdUserData = uPatchLodPing.mElements[elementIdxIn].mObjectIdUserData;
+		}
 	} 
 	else { // We do not split OR we have reached max.level (i.e., no more patch lod calls afterwards):
 		pxFillOut(renderingVariantIndex,
 		          uStart, uEnd, vStart, vEnd, 
 		          screenDists,
-		          elementIdxIn);
+		          elementIdxIn,
+				  aTM, curveIndex, userData);
 	}
 }
 
@@ -337,7 +429,7 @@ void main()
 		vec4 posWS_xtra  = tM * rawWS_xtra;
 		vec4 posCS_xtra  = toCS(posWS_xtra);
 
-#if DRAW_PATCH_EVAL_DEBUG_VIS
+#if DRAW_PATCH_EVAL_DEBUG_VIS_SCREEN_DISTANCES
 		{ DEBUG_VIS_WRAP_BEGIN
 			const vec3 vpc  = toScreen(posCS_xtra);
 			for (int i = -DEBUG_POINT_HALF_SIZE; i <= DEBUG_POINT_HALF_SIZE; ++i) {
@@ -393,30 +485,14 @@ void main()
 	if (pushConstants.mPerformFrustumCulling && ((workgroupAnd[0] & workgroupAnd[1]) != 0)) {
 		return;
 	}
-
-	// Only z==0 writes the split data
-	if (gl_LocalInvocationID.z != 0) {
-		return;
-	}
 #else
 	subgroupMemoryBarrierShared();
 #endif
 
-	// Before we decide about them splits, see if we must decide upon them different rendering variants (HYBRID METHOD):
-	if (HYBRID_VARIANT_INDEX == renderingVariantIndex) { 
-		// TODO: Implement a proper heuristic
-		if (gl_WorkGroupID.x % 2 == 0) {
-			renderingVariantIndex = 0;
-		}
-		else {
-			renderingVariantIndex = 4;
-		}
-	}
-
-	// Split-decision computed by only one thread:
-	if (!subgroupElect()) {
-		return;
-	}
+//	// Split-decision computed by only one thread:
+//	if (!subgroupElect()) {
+//		return;
+//	}
 
 	bool shallSplitU[2] = { splitU[0] SPLIT_OP splitU[1], splitU[2] SPLIT_OP splitU[3] };
 	bool shallSplitV[2] = { splitV[0] SPLIT_OP splitV[1], splitV[2] SPLIT_OP splitV[3] };
@@ -453,15 +529,18 @@ void main()
 			if (shallSplitU[i]) {
 				patchOut(renderingVariantIndex, levelIn, paramsStart.x                    , paramsStart.x + halfParamsRange.x, vStarts[i], vEnds[i], 
 				         vec2(max(screenDistsU[0], screenDistsU[1]), max(screenDistsV[i*2], screenDistsV[i*2 + 1])),
-				         elementIdxIn);
+				         elementIdxIn,
+				         tM, curveIndex, userData);
 				patchOut(renderingVariantIndex, levelIn, paramsStart.x + halfParamsRange.x, paramsStart.x + paramsRange.x    , vStarts[i], vEnds[i], 
 				         vec2(max(screenDistsU[2], screenDistsU[3]), max(screenDistsV[i*2], screenDistsV[i*2 + 1])),
-				         elementIdxIn);
+				         elementIdxIn,
+				         tM, curveIndex, userData);
 			}
 			else {
 				patchOut(renderingVariantIndex, levelIn, paramsStart.x                    , paramsStart.x + paramsRange.x    , vStarts[i], vEnds[i], 
 				         vec2(max(max(max(screenDistsU[0], screenDistsU[1]), screenDistsU[2]), screenDistsU[3]), max(screenDistsV[i*2], screenDistsV[i*2 + 1])),
-				         elementIdxIn);
+				         elementIdxIn,
+				         tM, curveIndex, userData);
 			}
 		}
 	}
@@ -472,15 +551,18 @@ void main()
 			if (shallSplitV[i]) {
 				patchOut(renderingVariantIndex, levelIn, uStarts[i], uEnds[i], paramsStart.y                    , paramsStart.y + halfParamsRange.y, 
 				         vec2(max(screenDistsU[i*2], screenDistsU[i*2 + 1]), max(screenDistsV[0], screenDistsV[1])),
-				         elementIdxIn);
+				         elementIdxIn,
+				         tM, curveIndex, userData);
 				patchOut(renderingVariantIndex, levelIn, uStarts[i], uEnds[i], paramsStart.y + halfParamsRange.y, paramsStart.y + paramsRange.y    , 
 				         vec2(max(screenDistsU[i*2], screenDistsU[i*2 + 1]), max(screenDistsV[2], screenDistsV[3])),
-				         elementIdxIn);
+				         elementIdxIn,
+				         tM, curveIndex, userData);
 			}
 			else {
 				patchOut(renderingVariantIndex, levelIn, uStarts[i], uEnds[i], paramsStart.y                    , paramsStart.y + paramsRange.y    , 
 				         vec2(max(screenDistsU[i*2], screenDistsU[i*2 + 1]), max(max(max(screenDistsV[0], screenDistsV[1]), screenDistsV[2]), screenDistsV[3])),
-				         elementIdxIn);
+				         elementIdxIn,
+				         tM, curveIndex, userData);
 			}
 		}
 	}
@@ -489,6 +571,7 @@ void main()
 		// No splits required
 		pxFillOut(renderingVariantIndex, paramsStart.x, paramsStart.x + paramsRange.x, paramsStart.y, paramsStart.y + paramsRange.y, 
 		          vec2(max(max(max(screenDistsU[0], screenDistsU[1]), screenDistsU[2]), screenDistsU[3]), max(max(max(screenDistsV[0], screenDistsV[1]), screenDistsV[2]), screenDistsV[3])),
-		          elementIdxIn);
+		          elementIdxIn,
+				  tM, curveIndex, userData);
 	}
 }

--- a/shaders/pass2x_patch_lod.comp
+++ b/shaders/pass2x_patch_lod.comp
@@ -220,10 +220,39 @@ void evalSplitDecision(bool aTransposeEval, vec2 aParamsStart, vec2 aParamsRange
 	}
 }
 
+float getCentralDifference(float u, float v, const mat4 aTM, const int curveIndex, const uvec3 userData, float h, float k) 
+{
+//	vec4 pos1 = aTM * paramToWS(u + h, v + k, curveIndex, userData);
+//	vec4 pos2 = aTM * paramToWS(u + h, v    , curveIndex, userData);
+//	vec4 pos3 = aTM * paramToWS(u    , v + k, curveIndex, userData);
+//	vec4 pos4 = aTM * paramToWS(u    , v    , curveIndex, userData);
+//	vec4 pos5 = aTM * paramToWS(u - h, v    , curveIndex, userData);
+//	vec4 pos6 = aTM * paramToWS(u    , v - k, curveIndex, userData);
+//	vec4 pos7 = aTM * paramToWS(u - h, v - k, curveIndex, userData);
+
+	vec2 params[7] = { vec2(u+h, v+k), vec2(u+h, v), vec2(u, v+k), vec2(u, v), vec2(u-h, v), vec2(u, v-k), vec2(u-h, v-k) };
+	vec3 pos[7];
+	for (int i = 0; i < 7; ++i) {
+		pos[i] = (aTM * paramToWS(params[i].x, params[i].y, curveIndex, userData)).xyz;
+	}
+
+#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
+	writeToCombinedAttachment(ivec2(toScreen(toCS(pos4)).xy), 0.0001, DEBUG_COLOR_SUBSAMPLE);
+#endif
+
+	vec3 fuv = (pos[0] - pos[1] - pos[2] + 2.0 * pos[3] - pos[4] - pos[5] + pos[6]) / (2 * h * k);
+	return length(fuv);
+}
+
 // This function measures if the parametric function varies strongly on a sub-pixel level:
 // (If it does, why not super-sample the patch?! If it doesn't no need for super sampling.)
-bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, mat4 aTM, int curveIndex, uvec3 userData)
+bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn)
 {
+	const uint  objectId              = uPatchLodPing.mElements[elementIdxIn].mObjectIdUserData[0];
+	const uvec3 userData              = uPatchLodPing.mElements[elementIdxIn].mObjectIdUserData.yzw;
+	const int   curveIndex            = uObjectData.mElements[objectId].mCurveIndex;
+	const mat4  tM                    = uObjectData.mElements[objectId].mTransformationMatrix;
+
 	// Parameter ranges for ~1px:
 	vec2 parameterRange      = vec2(uEnd - uStart, vEnd - vStart);
 	vec2 onePxParamRange     = parameterRange / screenDists;
@@ -232,100 +261,30 @@ bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec
 		uStart + parameterRange.x * 0.5 - onePxParamRange.x * 4.0,
 		vStart + parameterRange.y * 0.5 - onePxParamRange.y	* 4.0
 	);
-	
+
 	// Start in the middle:
 	float vParam = middlePxStartParams.y;
 	float uParam = middlePxStartParams.x + gl_SubgroupInvocationID * quarterPxParamRange.x;
 
-//	vec3  tanWSv     = posPongWS.xyz - posPingWS.xyz;
-//	float lenTanWSv  = length(tanWS);
+	float lolpx      = getCentralDifference(uParam, vParam, tM, curveIndex, userData, onePxParamRange.x,     onePxParamRange.y);
+	float lolquarter = getCentralDifference(uParam, vParam, tM, curveIndex, userData, quarterPxParamRange.x, quarterPxParamRange.y);
 
-	// We're going to take a look at quarter pixel neighbors and full pixel neighbors:
-	const uint pxNeighborIndex      = min(31, gl_SubgroupInvocationID % 4 == 0 ? gl_SubgroupInvocationID + 4 : gl_SubgroupInvocationID);
-	const uint pxBaseNeighborIndex  = uint(gl_SubgroupInvocationID / 4) * 4;
-	const uint quarterNeighborIndex = min(31, gl_SubgroupInvocationID + 1);
-
-//	float sumAbsAngleDiffSub = 0.0; // absolute differences between the angles on sub-pixel level
-	int count = 0;
-	int significantDiffs = 0;
+	if (subgroupElect())
+		debugPrintfEXT("lolpx[%f], lolquarter[%f]", lolpx, lolquarter);
 	
-	// v direction:
-	for (int i = 0; i < 32; ++i) {
-		vec4 posWS     = aTM * paramToWS(uParam, vParam, curveIndex, userData);
-		vec4 pxnPosWS  = subgroupShuffle(posWS, pxNeighborIndex);
-		vec4 qunPosWS  = subgroupShuffle(posWS, quarterNeighborIndex);
-
-		// Calc the tangents:
-		vec3 pxnTangTmp= pxnPosWS.xyz - posWS.xyz;
-		vec3 pxnTang   = subgroupShuffle(pxnTangTmp, pxBaseNeighborIndex); // regardless of this invocation's pxnTang, always pick the pxBase's value
-		float pxnLen   = length(pxnTang);
-
-		vec3 qunTang   = qunPosWS.xyz - posWS.xyz;
-		float qunLen   = length(qunTang);
-
-		if (pxnLen > 0 && qunLen > 0) {
-			pxnTang /= pxnLen;
-			qunTang /= qunLen;
-			count += 1;
-			if (dot(pxnTang, qunTang) < 0.9) {
-				significantDiffs += 1;
-			}
-		}
-
-#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
-//		if (gl_SubgroupInvocationID <= 8) {
-			writeToCombinedAttachment(ivec2(toScreen(toCS(posWS)).xy), 0.0001, DEBUG_COLOR_SUBSAMPLE);
-//		}
-#endif
-		// Next row:
-		vParam      += quarterPxParamRange.y;
-	}
-
-	// same same, but u direction:
-	vParam = middlePxStartParams.y + gl_SubgroupInvocationID * quarterPxParamRange.x;
-	uParam = middlePxStartParams.x;
-	for (int i = 0; i < 32; ++i) {
-		vec4 posWS     = aTM * paramToWS(uParam, vParam, curveIndex, userData);
-		vec4 pxnPosWS  = subgroupShuffle(posWS, pxNeighborIndex);
-		vec4 qunPosWS  = subgroupShuffle(posWS, quarterNeighborIndex);
-
-		// Calc the tangents:
-		vec3 pxnTangTmp= pxnPosWS.xyz - posWS.xyz;
-		vec3 pxnTang   = subgroupShuffle(pxnTangTmp, pxBaseNeighborIndex); // regardless of this invocation's pxnTang, always pick the pxBase's value
-		float pxnLen   = length(pxnTang);
-
-		vec3 qunTang   = qunPosWS.xyz - posWS.xyz;
-		float qunLen   = length(qunTang);
-
-		if (pxnLen > 0 && qunLen > 0) {
-			pxnTang /= pxnLen;
-			qunTang /= qunLen;
-			count += 1;
-			if (dot(pxnTang, qunTang) < 0.9) {
-				significantDiffs += 1;
-			}
-		}
-
-#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
-//		if (gl_SubgroupInvocationID <= 8) {
-			writeToCombinedAttachment(ivec2(toScreen(toCS(posWS)).xy), 0.0001, DEBUG_COLOR_SUBSAMPLE);
-//		}
-#endif
-		// Next row:
-		uParam      += quarterPxParamRange.x;
-	}
-
-	uint significantDiffsTotal = subgroupAdd(significantDiffs);
+	int count = lolpx > 0.0 && lolquarter > 0.0
+		? 1 : 0;
+	int significantDiffs = count > 0 && lolquarter * 4.0 > lolpx  // => no idea, what I'm doing
+		? 1 : 0;
+	
 	uint countTotal            = subgroupAdd(count);
-//	if (subgroupElect()) {
-//		debugPrintfEXT("significantDiffsTotal[%u], countTotal[%u]", significantDiffsTotal, countTotal);
-//	}
-	// If there are more than 6.67% of pixels that have sub-pixel detail => return true:
+	uint significantDiffsTotal = subgroupAdd(significantDiffs);
+
 	return (significantDiffsTotal * 15) > countTotal;
 }
 
 // renderingVariantIndex:  [0] = Tess_noAA, [1] = Tess_8xSS, [2] = Tess_4xSS_8xMS, [3] = PointRendered_direct, [4] = PointRendered_4xSS_local_fb, [5] = Hybrid
-void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn, mat4 aTM, int curveIndex, uvec3 userData) 
+void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn) 
 {
 	// Before we decide about them splits, see if we must decide upon them different rendering variants (HYBRID METHOD):
 	if (HYBRID_VARIANT_INDEX == renderingVariantIndex) { 
@@ -337,7 +296,7 @@ void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart
 		}
 		// TODO:  ^ Implement a proper heuristic => see here v
 
-		bool isBumpy = hasSubpixelFeatures(uStart, uEnd, vStart, vEnd, screenDists, aTM, curveIndex, userData);
+		bool isBumpy = hasSubpixelFeatures(uStart, uEnd, vStart, vEnd, screenDists, elementIdxIn);
 		renderingVariantIndex = isBumpy ? 4 : 0;
 	}
 
@@ -380,7 +339,7 @@ void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart
 }
 
 // renderingVariantIndex:  [0] = Tess_noAA, [1] = Tess_8xSS, [2] = Tess_4xSS_8xMS, [3] = PointRendered_direct, [4] = PointRendered_4xSS_local_fb, [5] = Hybrid
-void patchOut(int renderingVariantIndex, const uint levelIn, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn, mat4 aTM, int curveIndex, uvec3 userData) 
+void patchOut(int renderingVariantIndex, const uint levelIn, float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn) 
 {
 	// out (from ping->pong):
 	uint maxLevel = MAX_PATCH_SUBDIV_STEPS-1;
@@ -397,8 +356,7 @@ void patchOut(int renderingVariantIndex, const uint levelIn, float uStart, float
 		pxFillOut(renderingVariantIndex,
 		          uStart, uEnd, vStart, vEnd, 
 		          screenDists,
-		          elementIdxIn,
-				  aTM, curveIndex, userData);
+		          elementIdxIn);
 	}
 }
 
@@ -578,18 +536,15 @@ void main()
 			if (shallSplitU[i]) {
 				patchOut(renderingVariantIndex, levelIn, paramsStart.x                    , paramsStart.x + halfParamsRange.x, vStarts[i], vEnds[i], 
 				         vec2(max(screenDistsU[0], screenDistsU[1]), max(screenDistsV[i*2], screenDistsV[i*2 + 1])),
-				         elementIdxIn,
-				         tM, curveIndex, userData);
+				         elementIdxIn);
 				patchOut(renderingVariantIndex, levelIn, paramsStart.x + halfParamsRange.x, paramsStart.x + paramsRange.x    , vStarts[i], vEnds[i], 
 				         vec2(max(screenDistsU[2], screenDistsU[3]), max(screenDistsV[i*2], screenDistsV[i*2 + 1])),
-				         elementIdxIn,
-				         tM, curveIndex, userData);
+				         elementIdxIn);
 			}
 			else {
 				patchOut(renderingVariantIndex, levelIn, paramsStart.x                    , paramsStart.x + paramsRange.x    , vStarts[i], vEnds[i], 
 				         vec2(max(max(max(screenDistsU[0], screenDistsU[1]), screenDistsU[2]), screenDistsU[3]), max(screenDistsV[i*2], screenDistsV[i*2 + 1])),
-				         elementIdxIn,
-				         tM, curveIndex, userData);
+				         elementIdxIn);
 			}
 		}
 	}
@@ -600,18 +555,15 @@ void main()
 			if (shallSplitV[i]) {
 				patchOut(renderingVariantIndex, levelIn, uStarts[i], uEnds[i], paramsStart.y                    , paramsStart.y + halfParamsRange.y, 
 				         vec2(max(screenDistsU[i*2], screenDistsU[i*2 + 1]), max(screenDistsV[0], screenDistsV[1])),
-				         elementIdxIn,
-				         tM, curveIndex, userData);
+				         elementIdxIn);
 				patchOut(renderingVariantIndex, levelIn, uStarts[i], uEnds[i], paramsStart.y + halfParamsRange.y, paramsStart.y + paramsRange.y    , 
 				         vec2(max(screenDistsU[i*2], screenDistsU[i*2 + 1]), max(screenDistsV[2], screenDistsV[3])),
-				         elementIdxIn,
-				         tM, curveIndex, userData);
+				         elementIdxIn);
 			}
 			else {
 				patchOut(renderingVariantIndex, levelIn, uStarts[i], uEnds[i], paramsStart.y                    , paramsStart.y + paramsRange.y    , 
 				         vec2(max(screenDistsU[i*2], screenDistsU[i*2 + 1]), max(max(max(screenDistsV[0], screenDistsV[1]), screenDistsV[2]), screenDistsV[3])),
-				         elementIdxIn,
-				         tM, curveIndex, userData);
+				         elementIdxIn);
 			}
 		}
 	}
@@ -620,7 +572,6 @@ void main()
 		// No splits required
 		pxFillOut(renderingVariantIndex, paramsStart.x, paramsStart.x + paramsRange.x, paramsStart.y, paramsStart.y + paramsRange.y, 
 		          vec2(max(max(max(screenDistsU[0], screenDistsU[1]), screenDistsU[2]), screenDistsU[3]), max(max(max(screenDistsV[0], screenDistsV[1]), screenDistsV[2]), screenDistsV[3])),
-		          elementIdxIn,
-				  tM, curveIndex, userData);
+		          elementIdxIn);
 	}
 }

--- a/shaders/pass2x_patch_lod.comp
+++ b/shaders/pass2x_patch_lod.comp
@@ -220,59 +220,108 @@ void evalSplitDecision(bool aTransposeEval, vec2 aParamsStart, vec2 aParamsRange
 	}
 }
 
-bool measureSubpixelBumpiness(float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, mat4 aTM, int curveIndex, uvec3 userData)
+// This function measures if the parametric function varies strongly on a sub-pixel level:
+// (If it does, why not super-sample the patch?! If it doesn't no need for super sampling.)
+bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, mat4 aTM, int curveIndex, uvec3 userData)
 {
 	// Parameter ranges for ~1px:
 	vec2 parameterRange      = vec2(uEnd - uStart, vEnd - vStart);
 	vec2 onePxParamRange     = parameterRange / screenDists;
-	vec2 quarterPxParamRange = onePxParamRange;
+	vec2 quarterPxParamRange = onePxParamRange / 4.0;
 	vec2 middlePxStartParams = vec2(
-		uStart + parameterRange.x * 0.5 - onePxParamRange.x ,
-		vStart + parameterRange.y * 0.5 - onePxParamRange.y
+		uStart + parameterRange.x * 0.5 - onePxParamRange.x * 4.0,
+		vStart + parameterRange.y * 0.5 - onePxParamRange.y	* 4.0
 	);
 	
 	// Start in the middle:
-	float vParamPing = middlePxStartParams.y;
-	float vParamPong = vParamPing + quarterPxParamRange.y;
-	float uParam     = middlePxStartParams.x + gl_SubgroupInvocationID * quarterPxParamRange.x;
-	vec4  posPingWS  = aTM * paramToWS(uParam, vParamPing, curveIndex, userData);
-	vec4  posPongWS  = aTM * paramToWS(uParam, vParamPong, curveIndex, userData);
-	const uint neighborIndex = gl_SubgroupInvocationID == 31 ? gl_SubgroupInvocationID : gl_SubgroupInvocationID - 1;
-	vec4  posPongWSN = subgroupShuffle(posPongWS, neighborIndex);
-	vec3  normalPong = cross(normalize(posPongWSN.xyz - posPongWS.xyz), normalize(posPongWS.xyz - posPingWS.xyz));
-	vec3  normalPing = normalPong;
-	int sameDirCount = 0;
+	float vParam = middlePxStartParams.y;
+	float uParam = middlePxStartParams.x + gl_SubgroupInvocationID * quarterPxParamRange.x;
+
+//	vec3  tanWSv     = posPongWS.xyz - posPingWS.xyz;
+//	float lenTanWSv  = length(tanWS);
+
+	// We're going to take a look at quarter pixel neighbors and full pixel neighbors:
+	const uint pxNeighborIndex      = min(31, gl_SubgroupInvocationID % 4 == 0 ? gl_SubgroupInvocationID + 4 : gl_SubgroupInvocationID);
+	const uint pxBaseNeighborIndex  = uint(gl_SubgroupInvocationID / 4) * 4;
+	const uint quarterNeighborIndex = min(31, gl_SubgroupInvocationID + 1);
+
+//	float sumAbsAngleDiffSub = 0.0; // absolute differences between the angles on sub-pixel level
+	int count = 0;
+	int significantDiffs = 0;
 	
-	for (int i = 0; i < 8; ++i) {
-		// Next row:
-		vParamPing   = vParamPong;
-		vParamPong  += quarterPxParamRange.y;
-		posPingWS    = posPongWS;
-		posPongWS    = aTM * paramToWS(uParam, vParamPong, curveIndex, userData);
-		posPongWSN   = subgroupShuffle(posPongWS, neighborIndex);
+	// v direction:
+	for (int i = 0; i < 32; ++i) {
+		vec4 posWS     = aTM * paramToWS(uParam, vParam, curveIndex, userData);
+		vec4 pxnPosWS  = subgroupShuffle(posWS, pxNeighborIndex);
+		vec4 qunPosWS  = subgroupShuffle(posWS, quarterNeighborIndex);
 
-		normalPing   = normalPong;
-		normalPong   = cross(normalize(posPongWSN.xyz - posPongWS.xyz), normalize(posPongWS.xyz - posPingWS.xyz));
-		vec3 normalPongN = subgroupShuffle(normalPong, neighborIndex);
+		// Calc the tangents:
+		vec3 pxnTangTmp= pxnPosWS.xyz - posWS.xyz;
+		vec3 pxnTang   = subgroupShuffle(pxnTangTmp, pxBaseNeighborIndex); // regardless of this invocation's pxnTang, always pick the pxBase's value
+		float pxnLen   = length(pxnTang);
 
-		vec3 rotU    = cross(normalPong, normalPongN);
-		vec3 rotUN   = subgroupShuffle(rotU, neighborIndex);
-		vec3 rotV    = cross(normalPing, normalPong);
-		vec3 rotVN   = subgroupShuffle(rotV, neighborIndex);
+		vec3 qunTang   = qunPosWS.xyz - posWS.xyz;
+		float qunLen   = length(qunTang);
 
-		int sameDir      = gl_SubgroupInvocationID > 8 ? 0
-						 : ( (dot(rotU, rotUN) > 0.0 ? 1 : 0) 
-						   + (dot(rotV, rotVN) > 0.0 ? 1 : 0));
-		sameDirCount    += subgroupAdd(sameDir);
+		if (pxnLen > 0 && qunLen > 0) {
+			pxnTang /= pxnLen;
+			qunTang /= qunLen;
+			count += 1;
+			if (dot(pxnTang, qunTang) < 0.9) {
+				significantDiffs += 1;
+			}
+		}
 
 #if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
-		if (gl_SubgroupInvocationID <= 8) {
-			writeToCombinedAttachment(ivec2(toScreen(toCS(posPongWS)).xy), 0.0001, normalPong);
-		}
+//		if (gl_SubgroupInvocationID <= 8) {
+			writeToCombinedAttachment(ivec2(toScreen(toCS(posWS)).xy), 0.0001, DEBUG_COLOR_SUBSAMPLE);
+//		}
 #endif
+		// Next row:
+		vParam      += quarterPxParamRange.y;
 	}
 
-	return sameDirCount < 64;
+	// same same, but u direction:
+	vParam = middlePxStartParams.y + gl_SubgroupInvocationID * quarterPxParamRange.x;
+	uParam = middlePxStartParams.x;
+	for (int i = 0; i < 32; ++i) {
+		vec4 posWS     = aTM * paramToWS(uParam, vParam, curveIndex, userData);
+		vec4 pxnPosWS  = subgroupShuffle(posWS, pxNeighborIndex);
+		vec4 qunPosWS  = subgroupShuffle(posWS, quarterNeighborIndex);
+
+		// Calc the tangents:
+		vec3 pxnTangTmp= pxnPosWS.xyz - posWS.xyz;
+		vec3 pxnTang   = subgroupShuffle(pxnTangTmp, pxBaseNeighborIndex); // regardless of this invocation's pxnTang, always pick the pxBase's value
+		float pxnLen   = length(pxnTang);
+
+		vec3 qunTang   = qunPosWS.xyz - posWS.xyz;
+		float qunLen   = length(qunTang);
+
+		if (pxnLen > 0 && qunLen > 0) {
+			pxnTang /= pxnLen;
+			qunTang /= qunLen;
+			count += 1;
+			if (dot(pxnTang, qunTang) < 0.9) {
+				significantDiffs += 1;
+			}
+		}
+
+#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
+//		if (gl_SubgroupInvocationID <= 8) {
+			writeToCombinedAttachment(ivec2(toScreen(toCS(posWS)).xy), 0.0001, DEBUG_COLOR_SUBSAMPLE);
+//		}
+#endif
+		// Next row:
+		uParam      += quarterPxParamRange.x;
+	}
+
+	uint significantDiffsTotal = subgroupAdd(significantDiffs);
+	uint countTotal            = subgroupAdd(count);
+//	if (subgroupElect()) {
+//		debugPrintfEXT("significantDiffsTotal[%u], countTotal[%u]", significantDiffsTotal, countTotal);
+//	}
+	// If there are more than 6.67% of pixels that have sub-pixel detail => return true:
+	return (significantDiffsTotal * 15) > countTotal;
 }
 
 // renderingVariantIndex:  [0] = Tess_noAA, [1] = Tess_8xSS, [2] = Tess_4xSS_8xMS, [3] = PointRendered_direct, [4] = PointRendered_4xSS_local_fb, [5] = Hybrid
@@ -288,7 +337,7 @@ void pxFillOut(int renderingVariantIndex, float uStart, float uEnd, float vStart
 		}
 		// TODO:  ^ Implement a proper heuristic => see here v
 
-		bool isBumpy = measureSubpixelBumpiness(uStart, uEnd, vStart, vEnd, screenDists, aTM, curveIndex, userData);
+		bool isBumpy = hasSubpixelFeatures(uStart, uEnd, vStart, vEnd, screenDists, aTM, curveIndex, userData);
 		renderingVariantIndex = isBumpy ? 4 : 0;
 	}
 

--- a/shaders/pass2x_patch_lod.comp
+++ b/shaders/pass2x_patch_lod.comp
@@ -166,7 +166,7 @@ void evalSplitDecision(bool aTransposeEval, vec2 aParamsStart, vec2 aParamsRange
 	vec4 posWS  = aTM * rawWS;
 	posCS       = toCS(posWS);
 	// Note: No frustum check here. toScreen() should clamp to 
-	//       the frustum borders, which is what we want here:s
+	//       the frustum borders, which is what we want here:
 	const vec3 vpc           = toScreen(posCS);
 	const vec2 screenCoords  = vpc.xy;
 
@@ -220,30 +220,6 @@ void evalSplitDecision(bool aTransposeEval, vec2 aParamsStart, vec2 aParamsRange
 	}
 }
 
-float getCentralDifference(float u, float v, const mat4 aTM, const int curveIndex, const uvec3 userData, float h, float k) 
-{
-//	vec4 pos1 = aTM * paramToWS(u + h, v + k, curveIndex, userData);
-//	vec4 pos2 = aTM * paramToWS(u + h, v    , curveIndex, userData);
-//	vec4 pos3 = aTM * paramToWS(u    , v + k, curveIndex, userData);
-//	vec4 pos4 = aTM * paramToWS(u    , v    , curveIndex, userData);
-//	vec4 pos5 = aTM * paramToWS(u - h, v    , curveIndex, userData);
-//	vec4 pos6 = aTM * paramToWS(u    , v - k, curveIndex, userData);
-//	vec4 pos7 = aTM * paramToWS(u - h, v - k, curveIndex, userData);
-
-	vec2 params[7] = { vec2(u+h, v+k), vec2(u+h, v), vec2(u, v+k), vec2(u, v), vec2(u-h, v), vec2(u, v-k), vec2(u-h, v-k) };
-	vec3 pos[7];
-	for (int i = 0; i < 7; ++i) {
-		pos[i] = (aTM * paramToWS(params[i].x, params[i].y, curveIndex, userData)).xyz;
-	}
-
-#if DRAW_PATCH_EVAL_DEBUG_VIS_BUMPINESS_EVAL
-	writeToCombinedAttachment(ivec2(toScreen(toCS(pos4)).xy), 0.0001, DEBUG_COLOR_SUBSAMPLE);
-#endif
-
-	vec3 fuv = (pos[0] - pos[1] - pos[2] + 2.0 * pos[3] - pos[4] - pos[5] + pos[6]) / (2 * h * k);
-	return length(fuv);
-}
-
 // This function measures if the parametric function varies strongly on a sub-pixel level:
 // (If it does, why not super-sample the patch?! If it doesn't no need for super sampling.)
 bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn)
@@ -256,31 +232,70 @@ bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec
 	// Parameter ranges for ~1px:
 	vec2 parameterRange      = vec2(uEnd - uStart, vEnd - vStart);
 	vec2 onePxParamRange     = parameterRange / screenDists;
-	vec2 quarterPxParamRange = onePxParamRange / 4.0;
 	vec2 middlePxStartParams = vec2(
 		uStart + parameterRange.x * 0.5 - onePxParamRange.x * 4.0,
 		vStart + parameterRange.y * 0.5 - onePxParamRange.y	* 4.0
 	);
 
 	// Start in the middle:
-	float vParam = middlePxStartParams.y;
-	float uParam = middlePxStartParams.x + gl_SubgroupInvocationID * quarterPxParamRange.x;
+	float uParam = middlePxStartParams.x + gl_LocalInvocationID.x * onePxParamRange.x;
+	float vParam = middlePxStartParams.y + gl_LocalInvocationID.y * onePxParamRange.y;
+	const uint neighborX  = calcInvocationIdFrom2DIndices(gl_LocalInvocationID.xy + uvec2(1, 0), gl_WorkGroupSize.xy);
+	const uint neighborY  = calcInvocationIdFrom2DIndices(gl_LocalInvocationID.xy + uvec2(0, 1), gl_WorkGroupSize.xy);
+	const uint neighborXY = calcInvocationIdFrom2DIndices(gl_LocalInvocationID.xy + uvec2(1, 1), gl_WorkGroupSize.xy);
 
-	float lolpx      = getCentralDifference(uParam, vParam, tM, curveIndex, userData, onePxParamRange.x,     onePxParamRange.y);
-	float lolquarter = getCentralDifference(uParam, vParam, tM, curveIndex, userData, quarterPxParamRange.x, quarterPxParamRange.y);
+	vec4 pos0WS = tM * paramToWS(uParam, vParam, curveIndex, userData);
+	vec4 pos0CS = toCS(pos0WS);
+	vec3 ndc0   = pos0CS.xyz / pos0CS.w;
+	vec3 vpc0   = toScreen(pos0CS);
 
-	if (subgroupElect())
-		debugPrintfEXT("lolpx[%f], lolquarter[%f]", lolpx, lolquarter);
-	
-	int count = lolpx > 0.0 && lolquarter > 0.0
-		? 1 : 0;
-	int significantDiffs = count > 0 && lolquarter * 4.0 > lolpx  // => no idea, what I'm doing
-		? 1 : 0;
-	
-	uint countTotal            = subgroupAdd(count);
-	uint significantDiffsTotal = subgroupAdd(significantDiffs);
+	vec4 posCsU   = subgroupShuffle(pos0CS, neighborX);
+	vec4 posCsV   = subgroupShuffle(pos0CS, neighborY);
+	vec4 posCsUV  = subgroupShuffle(pos0CS, neighborXY);
 
-	return (significantDiffsTotal * 15) > countTotal;
+	uint different = 0;
+	uint total = 0;
+
+	const int NumTests = 3;
+	if (gl_LocalInvocationID.x < gl_WorkGroupSize.x - 1 && gl_LocalInvocationID.y < gl_WorkGroupSize.y - 1) {
+//		if (length(toScreen(posCsU).xy - vpc0.xy)  < 4.0 ||
+//		    length(toScreen(posCsV).xy - vpc0.xy)  < 4.0 ||
+//			length(toScreen(posCsUV).xy - vpc0.xy) < 4.0) {
+//			different += NumTests;
+//			total     += NumTests;
+//		}
+//		else {
+			const float offsets[10] = { 0.5, 0.333333, 0.2, 0.1428, 0.090909, 
+										0.5, 0.333333, 0.2, 0.1428, 0.090909 };
+			const uvec2 selectedOffsets = uvec2(gl_LocalInvocationID.x % 5, gl_LocalInvocationID.y % 5);
+			for (uint i = 0; i < NumTests; ++i) {
+				// Calc interpolated position:
+				float offU     = offsets[selectedOffsets.x + i];
+				float offV     = offsets[selectedOffsets.y + i];
+				vec4 bLerpedCS = getBilinearInterpolated(pos0CS, posCsU, posCsV, posCsUV, offU, offV);
+				vec4 subWS     = tM * paramToWS(uParam + onePxParamRange.x * offU, vParam + onePxParamRange.y * offV, curveIndex, userData);
+				vec4 subCS     = toCS(subWS);
+
+				// Compare interpolated with computed normals in NDC:
+				float angleDiff            = dot(normalize(bLerpedCS.xyz/bLerpedCS.w - ndc0.xyz), normalize(subCS.xyz/subCS.w - ndc0.xyz));
+				const float angleThreshold = 0.98; // 0.97 => ~14° | 0.98 => ~11° | 0.99 => ~8°
+				different += angleDiff < angleThreshold ? 1 : 0;
+
+//				// Measuring distances between pixels in screen space is probably not really what we want:
+//				float dist   = length(toScreen(bLerped).xy - toScreen(subCS).xy);
+//				different   += dist > 1.0 ? 1 : 0
+			}
+			total += NumTests;
+//		}
+	}
+
+	uint differentTotal = subgroupAdd(different);
+	uint totalTotal     = subgroupAdd(total);
+
+//	if (subgroupElect())
+//		debugPrintfEXT("differentTotal[%u], totalTotal[%u]", differentTotal, totalTotal);
+
+	return (differentTotal * 15) > totalTotal;
 }
 
 // renderingVariantIndex:  [0] = Tess_noAA, [1] = Tess_8xSS, [2] = Tess_4xSS_8xMS, [3] = PointRendered_direct, [4] = PointRendered_4xSS_local_fb, [5] = Hybrid

--- a/shaders/pass2x_patch_lod.comp
+++ b/shaders/pass2x_patch_lod.comp
@@ -245,48 +245,47 @@ bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec
 	const uint neighborXY = calcInvocationIdFrom2DIndices(gl_LocalInvocationID.xy + uvec2(1, 1), gl_WorkGroupSize.xy);
 
 	vec4 pos0WS = tM * paramToWS(uParam, vParam, curveIndex, userData);
-	vec4 pos0CS = toCS(pos0WS);
-	vec3 ndc0   = pos0CS.xyz / pos0CS.w;
-	vec3 vpc0   = toScreen(pos0CS);
-
-	vec4 posCsU   = subgroupShuffle(pos0CS, neighborX);
-	vec4 posCsV   = subgroupShuffle(pos0CS, neighborY);
-	vec4 posCsUV  = subgroupShuffle(pos0CS, neighborXY);
+	vec4 posU   = subgroupShuffle(pos0WS, neighborX);
+	vec4 posV   = subgroupShuffle(pos0WS, neighborY);
+	vec3 nrm0   = normalize(cross(posU.xyz - pos0WS.xyz, posV.xyz - pos0WS.xyz));
+	vec3 nrmU   = subgroupShuffle(nrm0  , neighborX );
+	vec3 nrmV   = subgroupShuffle(nrm0  , neighborY );
+	vec3 nrmUV  = subgroupShuffle(nrm0  , neighborXY);
 
 	uint different = 0;
 	uint total = 0;
 
-	const int NumTests = 3;
-	if (gl_LocalInvocationID.x < gl_WorkGroupSize.x - 1 && gl_LocalInvocationID.y < gl_WorkGroupSize.y - 1) {
-//		if (length(toScreen(posCsU).xy - vpc0.xy)  < 4.0 ||
-//		    length(toScreen(posCsV).xy - vpc0.xy)  < 4.0 ||
-//			length(toScreen(posCsUV).xy - vpc0.xy) < 4.0) {
-//			different += NumTests;
-//			total     += NumTests;
-//		}
-//		else {
-			const float offsets[10] = { 0.5, 0.333333, 0.2, 0.1428, 0.090909, 
-										0.5, 0.333333, 0.2, 0.1428, 0.090909 };
-			const uvec2 selectedOffsets = uvec2(gl_LocalInvocationID.x % 5, gl_LocalInvocationID.y % 5);
-			for (uint i = 0; i < NumTests; ++i) {
-				// Calc interpolated position:
-				float offU     = offsets[selectedOffsets.x + i];
-				float offV     = offsets[selectedOffsets.y + i];
-				vec4 bLerpedCS = getBilinearInterpolated(pos0CS, posCsU, posCsV, posCsUV, offU, offV);
-				vec4 subWS     = tM * paramToWS(uParam + onePxParamRange.x * offU, vParam + onePxParamRange.y * offV, curveIndex, userData);
-				vec4 subCS     = toCS(subWS);
+	const int NumTests = 9;
+	const vec2 offsets[NumTests] = {
+		vec2(0.5,      0.5     ),
+		vec2(0.5,      0.333333),
+		vec2(0.5,      0.2     ),
+		vec2(0.333333, 0.5     ),
+		vec2(0.333333, 0.333333),
+		vec2(0.333333, 0.2     ),
+		vec2(0.2,      0.5     ),
+		vec2(0.2,      0.333333),
+		vec2(0.2,      0.2     )
+	};
+	
+	for (uint i = 0; i < NumTests; ++i) {
+		// Calc interpolated normal:
+		vec2 curOff    = offsets[i];
+		vec3 lerpedNrm = getBilinearInterpolated(nrm0, nrmU, nrmV, nrmUV, curOff.x, curOff.y);
 
-				// Compare interpolated with computed normals in NDC:
-				float angleDiff            = dot(normalize(bLerpedCS.xyz/bLerpedCS.w - ndc0.xyz), normalize(subCS.xyz/subCS.w - ndc0.xyz));
-				const float angleThreshold = 0.98; // 0.97 => ~14° | 0.98 => ~11° | 0.99 => ~8°
-				different += angleDiff < angleThreshold ? 1 : 0;
+		// Calc subsampled normal:
+		vec4 sspos0WS = tM * paramToWS(uParam + onePxParamRange.x * curOff.x, vParam + onePxParamRange.y * curOff.y, curveIndex, userData);
+		vec4 ssposU   = subgroupShuffle(sspos0WS, neighborX);
+		vec4 ssposV   = subgroupShuffle(sspos0WS, neighborY);
+		if (gl_LocalInvocationID.x < gl_WorkGroupSize.x - 1 && gl_LocalInvocationID.y < gl_WorkGroupSize.y - 1) {
+			vec3 ssnrm0   = normalize(cross(ssposU.xyz - sspos0WS.xyz, ssposV.xyz - sspos0WS.xyz));
 
-//				// Measuring distances between pixels in screen space is probably not really what we want:
-//				float dist   = length(toScreen(bLerped).xy - toScreen(subCS).xy);
-//				different   += dist > 1.0 ? 1 : 0
-			}
+			// Compare interpolated with subsampled normal:
+			float angleDiff            = dot(normalize(lerpedNrm), ssnrm0);
+			const float angleThreshold = 0.98; // 0.97 => ~14° | 0.98 => ~11° | 0.99 => ~8°
+			different += angleDiff < angleThreshold ? 1 : 0;
 			total += NumTests;
-//		}
+		}
 	}
 
 	uint differentTotal = subgroupAdd(different);

--- a/shaders/pass3_px_fill_local_fb.comp
+++ b/shaders/pass3_px_fill_local_fb.comp
@@ -479,7 +479,7 @@ void main()
 #endif
 
 			if (colorDivisor > 0.0) {
-				ivec2 globalFbCoords = ivec2(x, y) + screenCoordsLB + ivec2(100, 0); // TODO: remove 100 (just for debug purposes);
+				ivec2 globalFbCoords = ivec2(x, y) + screenCoordsLB;
 				uint64_t resolvedData = getUint64ForFramebuffer(minDepth, avgColor);
 #if DEBUG_PATCH_FOCUS
 				if (gl_WorkGroupID.x == DEBUG_PATCH_X && gl_WorkGroupID.y == DEBUG_PATCH_Y) {


### PR DESCRIPTION
The decision is based on evaluation of 7x3 pixels in the middle of a parameter patch, comparing normals of sub-samples to interpolated normals: If they differ too much, the patch is scheduled for rendering with super sampling.
This functionality is implemented in `pass2x_patch_lod.comp` -> `bool hasSubpixelFeatures(float uStart, float uEnd, float vStart, float vEnd, vec2 screenDists, const uint elementIdxIn)`.